### PR TITLE
Fix minor typo in Slide 23 caption

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
             </a>
           </td>
           <td class="note">
-            Namely, we  href, #we had a lot of process that was prophylactic. It was built with the intent of finding production problems before product
+            Namely, we  had a lot of process that was prophylactic. It was built with the intent of finding production problems before product
           </td>
         </tr>
         </tr>


### PR DESCRIPTION
Fixing a little typo I noticed in Slide 23's caption:

<img width="1230" alt="screen shot 2017-05-12 at 12 53 08 pm" src="https://cloud.githubusercontent.com/assets/994938/26014608/27f4258c-3712-11e7-8f73-f8e7227e9f00.png">

Feel free to close if I'm missing some deep, subtle reference here.
